### PR TITLE
Add handler to avoid message "No handlers could..

### DIFF
--- a/alignak_backend_client/client.py
+++ b/alignak_backend_client/client.py
@@ -40,7 +40,7 @@ from requests.auth import HTTPBasicAuth
 
 logger = getLogger(__name__)
 # Check if logger has already handler to prevent override it
-if len(logger.handlers):
+if logger.handlers:
     logger.addHandler(logger.handlers)
 else:
     logging.basicConfig()

--- a/alignak_backend_client/client.py
+++ b/alignak_backend_client/client.py
@@ -25,6 +25,7 @@
 """
 import json
 import traceback
+import logging
 from logging import getLogger, DEBUG, WARNING
 
 import math
@@ -36,8 +37,14 @@ import requests
 from requests import Timeout, HTTPError
 from requests.auth import HTTPBasicAuth
 
-# Set logger level to WARNING, this to allow global application DEBUG logs without being spammed...
+
 logger = getLogger(__name__)
+# Check if logger has already handler to prevent override it
+if len(logger.handlers):
+    logger.addHandler(logger.handlers)
+else:
+    logging.basicConfig()
+# Set logger level to WARNING, this to allow global application DEBUG logs without being spammed...
 logger.setLevel(WARNING)
 
 # Disable default logs for requests and urllib3 libraries ...


### PR DESCRIPTION
Ref #10

Add handler if exist or create one if not. 

Like that alignak-backend-client does not override existing handler and does not display anymore _No handlers could be found for logger "alignak_backend_client.client_  message.