### PR TITLE
Remove os.link Seems not needed by setup.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@
 
 import os
 import sys
-del os.link
+
 from importlib import import_module
 
 try:


### PR DESCRIPTION
It seems this line as no effect. As describe in #19, in Py2.7 on Windows, `os.link` raise an error.