### PR TITLE
Fix #36: default realm creation

### DIFF
--- a/alignak_backend_client/backend_client.py
+++ b/alignak_backend_client/backend_client.py
@@ -958,9 +958,13 @@ class BackendUpdate(object):
                     else:
                         item_data[field] = found
 
-                if '_realm' not in item_data:
+                if resource_name not in ['realm'] and '_realm' not in item_data:
                     logger.info("add default realm to the data")
                     item_data.update({'_realm': self.default_realm})
+
+                if resource_name in ['realm'] and '_realm' not in item_data:
+                    logger.info("add parent realm to the data")
+                    item_data.update({'_parent': self.default_realm})
 
                 if '_id' in item_data:
                     item_data.pop('_id')

--- a/test/alignak-backend-cli-tests.py
+++ b/test/alignak-backend-cli-tests.py
@@ -220,6 +220,23 @@ class TestAlignakBackendCli(unittest2.TestCase):
         ))
         assert exit_code == 0
 
+        # Create a realm
+        # First, dry-run ... it will not create!
+        exit_code = subprocess.call(shlex.split(
+            'python ../alignak_backend_client/backend_client.py -t realm -c add test_realm'
+        ))
+        assert exit_code == 0
+        # Then we create :)
+        exit_code = subprocess.call(shlex.split(
+            'python ../alignak_backend_client/backend_client.py -t realm add test_realm'
+        ))
+        assert exit_code == 0
+        # Already exists!
+        exit_code = subprocess.call(shlex.split(
+            'python ../alignak_backend_client/backend_client.py -t realm add test_realm'
+        ))
+        assert exit_code == 2
+
         # Create hosts
         # First, dry-run ... it will not create!
         exit_code = subprocess.call(shlex.split(


### PR DESCRIPTION
If no realm is specified, use default realm as `_parent` rather than `_realm`